### PR TITLE
[FIX] Part creation when no sprint selected

### DIFF
--- a/src/features/home/editor/listParts/table/PartsTable.tsx
+++ b/src/features/home/editor/listParts/table/PartsTable.tsx
@@ -11,8 +11,8 @@ const PartsTable: React.FC<Props> = ({ parts }) => {
         <tr key={index}>
             <td>{part.id}</td>
             <td>{part.name}</td>
-            <td>{part.cards.length}</td>
-            <td>{part.cards.filter(item => item.sprint.active).length}</td>
+            <td>{part.cards?.length || "No sprint selected"}</td>
+            <td>{part.cards?.filter(item => item.sprint.active).length || "No sprint selected"}</td>
         </tr>
     ));
 


### PR DESCRIPTION
FIX #79 

Now the text "no sprint selected" appear in the columns needing a sprint to avoid the crash